### PR TITLE
ci: remove pinned rust toolchain from semver check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - uses: obi1kenobi/cargo-semver-checks-action@v2
-      with:
-        # Pinned until cargo-semver-checks supports rustdoc format v57 (Rust 1.93+)
-        rust-toolchain: "1.92.0"
 
   build-test-lint:
     name: Build, Test & Lint


### PR DESCRIPTION
We don't need this anymore, and more importantly `cargo-semver-check`
itself now requires MSRV => 1.93 so it won't even build/install with
the older pinned version.

Signed-off-by: John Eckersberg <dev@eckersberg.com>
